### PR TITLE
Pololu ToF sensor, DriveToPose, SparkUtil

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,5 +56,6 @@
     "edu.wpi.first.math.proto.*",
     "edu.wpi.first.math.**.proto.*",
     "edu.wpi.first.math.**.struct.*",
-  ]
+  ],
+  "java.debug.settings.vmArgs": "-enableassertions"
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -189,7 +189,7 @@ public final class Constants {
     public static final int kOperatorControllerPort = 1;
     public static final double kMaxRadPerSec = DriveConstants.kMaxAngularSpeedRadiansPerSecond;
     public static final double kMaxMetersPerSec = DriveConstants.kMaxSpeedMetersPerSecond;
-    
+
     public static final int kA = 1;
     public static final int kB = 2;
     public static final int kX = 3;
@@ -210,7 +210,7 @@ public final class Constants {
 
     public static final int kZeroGyro = kStart;
     public static final int kFaceReef = kY;
-    
+
     public static final double kDebounceSeconds = 0.01;
 
     public static final double kJoystickDeadband = 0.05;
@@ -319,15 +319,15 @@ public final class Constants {
         (aprilTag1.getX() + aprilTag2.getX()) / 2.0, (aprilTag1.getY() + aprilTag2.getY()) / 2.0);
       return centerOfReef;
     }
-    
+
     public static final Translation2d kBlueReef = calculateReefCenter(18, 21);
     public static final Translation2d kRedReef = calculateReefCenter(10, 7);
-    
+
     public static final ArrayList<Pose2d> kBlueCoralStations = new ArrayList<>() {{
       add(getAprilTagPose(kAprilTagFieldLayout, 13));
       add(getAprilTagPose(kAprilTagFieldLayout, 12));
     }};
-    
+
     public static final ArrayList<Pose2d> kRedCoralStations = new ArrayList<>() {{
       add(getAprilTagPose(kAprilTagFieldLayout, 1));
       add(getAprilTagPose(kAprilTagFieldLayout, 2));

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -258,7 +258,7 @@ public final class Constants {
 
   public static final class FieldConstants {
     private static final AprilTagFieldLayout loadTransformedAprilTagFieldLayout() {
-      final AprilTagFieldLayout rawLayout = AprilTagFields.k2025Reefscape.loadAprilTagLayoutField();
+      final AprilTagFieldLayout rawLayout = AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape);
       Map<Integer, Rotation3d> rotations = Map.of(
         // In order to adjust an AprilTag's rotation, specify non-zero roll/pitch/yaw, as viewed
         // from perspective of the field XYZ axes. For example, if the blue speaker AprilTag is

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -300,6 +300,11 @@ public final class Constants {
   }
 
   public static final class DriveCommandConstants {
+    public static final double kDefaultTranslationPosToleranceMeters = 0.02;
+    public static final double kDefaultTranslationVelToleranceMetersPerSecond = 0.01;
+    public static final double kDefaultAnglePosToleranceRadians = Units.degreesToRadians(2.0);
+    public static final double kDefaultAngleVelToleranceRadiansPerSecond = Units.degreesToRadians(1.0);
+
     public static final PIDF kTranslatingPIDF = new PIDF(0.0, 0.0, 0.0, 0.0); //TODO: Tune.
     public static final PIDF kTurningPIDF = new PIDF(3.0, 0.0, 0.0, 0.2); //TODO: Update the PIDF values (copied from AC/DC)
   }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -299,11 +299,8 @@ public final class Constants {
     );
   }
 
-  public static final class ReefConstants {
-    public static final PIDF kTurningPIDF = new PIDF(3.0, 0.0, 0.0, 0.2); //TODO: Update the PIDF values (copied from AC/DC)
-  }
-  
-  public static final class StationConstants {
+  public static final class DriveCommandConstants {
+    public static final PIDF kTranslatingPIDF = new PIDF(0.0, 0.0, 0.0, 0.0); //TODO: Tune.
     public static final PIDF kTurningPIDF = new PIDF(3.0, 0.0, 0.0, 0.2); //TODO: Update the PIDF values (copied from AC/DC)
   }
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -37,7 +37,7 @@ public class RobotContainer {
   private final CameraSubsystem m_cameraSystem =
     CameraConstants.kEnable ? new CameraSubsystem(CameraConstants.kCameraConfigs) : null;
   public final DriveSubsystem m_robotDrive = new DriveSubsystem(m_cameraSystem);
-  private final HandlerSubsystem m_handler = new HandlerSubsystem(HandlerConstants.kMotorID);
+  private final HandlerSubsystem m_handler = new HandlerSubsystem(HandlerConstants.kMotorID, HandlerConstants.kmotorConfig);
   GenericHID m_driverController = new GenericHID(OIConstants.kDriverControllerPort);
   GenericHID m_operatorController = new GenericHID(OIConstants.kOperatorControllerPort);
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -111,11 +111,11 @@ public class RobotContainer {
         m_robotDrive.zeroGyro();
       }, m_robotDrive
     ));
-    
+
     new JoystickButton(m_driverController, OIConstants.kFaceReef)
       .debounce(OIConstants.kDebounceSeconds)
       .whileTrue(new FaceReef(
-        m_robotDrive, 
+        m_robotDrive,
         () -> getXSpeedInput(),
         () -> getYSpeedInput()));
   }

--- a/src/main/java/frc/robot/commands/DriveToPose.java
+++ b/src/main/java/frc/robot/commands/DriveToPose.java
@@ -1,0 +1,192 @@
+package frc.robot.commands;
+
+import edu.wpi.first.math.controller.ProfiledPIDController;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.trajectory.TrapezoidProfile;
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.Constants;
+import frc.robot.Constants.DriveCommandConstants;
+import frc.robot.Constants.DriveConstants;
+import frc.robot.subsystems.DriveSubsystem;
+import frc.robot.utilities.PIDF;
+import frc.robot.utilities.TunablePIDF;
+
+/** Drive straight to a given pose. Position and angle are handled independently, such that if the
+ *  robot has to drive a significant distance, the final angle is reached before translation
+ *  completes. Conversely, short translations may complete before rotation completes. */
+public class DriveToPose extends Command {
+  private final Pose2d m_pose;
+  private final DriveSubsystem m_drive;
+  private final double m_SquaredTranslationPosToleranceMeters;
+  private final double m_SquaredTranslationVelToleranceMetersPerDt;
+
+  private static final TunablePIDF translatingPIDF = new TunablePIDF("DriveToPose.translatingPIDF",
+    DriveCommandConstants.kTranslatingPIDF);
+  private static final TunablePIDF turningPIDF = new TunablePIDF("DriveToPose.turningPIDF",
+    DriveCommandConstants.kTurningPIDF);
+
+  private ProfiledPIDController m_xController = new ProfiledPIDController(
+    translatingPIDF.get().p(),
+    translatingPIDF.get().i(),
+    translatingPIDF.get().d(),
+    new TrapezoidProfile.Constraints(0.0, 0.0), // Dynamically scaled.
+    Constants.kDt);
+  private ProfiledPIDController m_yController = new ProfiledPIDController(
+    translatingPIDF.get().p(),
+    translatingPIDF.get().i(),
+    translatingPIDF.get().d(),
+    new TrapezoidProfile.Constraints(0.0, 0.0), // Dynamically scaled.
+    Constants.kDt);
+  private ProfiledPIDController m_angleController = new ProfiledPIDController(
+    turningPIDF.get().p(),
+    turningPIDF.get().i(),
+    turningPIDF.get().d(),
+    new TrapezoidProfile.Constraints(
+      DriveConstants.kMaxAngularSpeedRadiansPerSecond,
+      DriveConstants.kMaxAngularAccelerationRadiansPerSecondSquared),
+    Constants.kDt);
+
+  private static double square(double x) {
+    return x * x;
+  }
+
+  public DriveToPose(Pose2d pose, DriveSubsystem drive,
+      double translationPosToleranceMeters, double translationVelToleranceMetersPerSecond,
+      double anglePosToleranceRadians, double angleVelToleranceRadiansPerSecond) {
+    m_pose = pose;
+    m_drive = drive;
+    m_SquaredTranslationPosToleranceMeters = square(translationPosToleranceMeters);
+    m_SquaredTranslationVelToleranceMetersPerDt =
+      square(Constants.kDt * translationVelToleranceMetersPerSecond);
+
+    m_angleController.setTolerance(anglePosToleranceRadians,
+      Constants.kDt * angleVelToleranceRadiansPerSecond);
+
+    addRequirements(m_drive);
+  }
+
+  public DriveToPose(Pose2d pose, DriveSubsystem drive) {
+    this(pose, drive,
+      DriveCommandConstants.kDefaultTranslationPosToleranceMeters,
+      DriveCommandConstants.kDefaultTranslationVelToleranceMetersPerSecond,
+      DriveCommandConstants.kDefaultAnglePosToleranceRadians,
+      DriveCommandConstants.kDefaultAngleVelToleranceRadiansPerSecond);
+  }
+
+  private Translation2d getDesiredTranslation(Pose2d robotPose) {
+    return m_pose.getTranslation();
+  }
+
+  private Translation2d getTranslationDeviation(Pose2d robotPose) {
+    return getDesiredTranslation(robotPose).minus(robotPose.getTranslation());
+  }
+
+  private Rotation2d getDesiredRotation(Pose2d robotPose) {
+    return m_pose.getRotation();
+  }
+
+  private Rotation2d getRotationDeviation(Pose2d robotPose) {
+    Rotation2d currentRotation = robotPose.getRotation();
+    Rotation2d desiredRotation = getDesiredRotation(robotPose);
+    Rotation2d rotationDeviation = currentRotation.minus(desiredRotation);
+    return rotationDeviation;
+  }
+
+  /* Dynamically scale the x,y controller constraints such that the combined x,y component
+   * movements combine to follow a straight line. Absent rescaling, the robot typically would
+   * initially move at a 45 degree angle relative to the axes, then arc to horizontal or vertical
+   * movement until reaching the final pose.
+   *
+   * A simpler strategy would be to scale the controller constraints once during command
+   * initialization, but if the the angle relative to an axis were close to 0, the controller
+   * would be incapable of significant movement along the other axis, and if the robot were to
+   * deviate from the intended trajectory, the controller would be incapable of correction. */
+  private void scaleXYConstraints(Pose2d robotPose) {
+    Translation2d translationDeviation = getTranslationDeviation(robotPose);
+    Rotation2d translationAngle = translationDeviation.getAngle();
+    double xFactor = translationAngle.getCos();
+    m_xController.setConstraints(new TrapezoidProfile.Constraints(
+      xFactor * DriveConstants.kMaxSpeedMetersPerSecond,
+      xFactor * DriveConstants.kMaxAccelerationMetersPerSecondSquared
+    ));
+    double yFactor = translationAngle.getSin();
+    m_yController.setConstraints(new TrapezoidProfile.Constraints(
+      yFactor * DriveConstants.kMaxSpeedMetersPerSecond,
+      yFactor * DriveConstants.kMaxAccelerationMetersPerSecondSquared
+    ));
+  }
+
+  @Override
+  public void initialize() {
+    Pose2d robotPose = m_drive.getPose();
+    Translation2d translationDeviation = getTranslationDeviation(robotPose);
+    Translation2d velocity = m_drive.getVelocity();
+
+    scaleXYConstraints(robotPose);
+    m_xController.reset(
+      translationDeviation.getX(),
+      velocity.getX()
+    );
+    m_yController.reset(
+      translationDeviation.getY(),
+      velocity.getY()
+    );
+    m_angleController.reset(
+      getRotationDeviation(robotPose).getRadians(),
+      m_drive.getAngularVelocity()
+    );
+  }
+
+  @Override
+  public void execute() {
+    Pose2d robotPose = m_drive.getPose();
+    Translation2d translationDeviation = getTranslationDeviation(robotPose);
+    Rotation2d rotationDeviation = getRotationDeviation(robotPose);
+
+    updateConstants();
+
+    scaleXYConstraints(robotPose);
+    double xVelocity = m_xController.calculate(translationDeviation.getX());
+    double yVelocity = m_yController.calculate(translationDeviation.getY());
+    double angleVelocity = m_angleController.calculate(rotationDeviation.getRadians());
+    m_drive.drive(
+      xVelocity,
+      yVelocity,
+      angleVelocity,
+      true);
+  }
+
+  private void updateConstants() {
+    if (translatingPIDF.hasChanged()) {
+      PIDF pidf = translatingPIDF.get();
+      m_xController.setPID(pidf.p(), pidf.i(), pidf.d());
+    }
+    if (turningPIDF.hasChanged()) {
+      PIDF pidf = turningPIDF.get();
+      m_angleController.setPID(pidf.p(), pidf.i(), pidf.d());
+    }
+  }
+
+  private boolean atSetpoint() {
+    // Extract error values from the x,y controllers and combine them such that the tolerance
+    // defines a circle rather than a square.
+    double xPosError = m_xController.getPositionError();
+    double yPosError = m_yController.getPositionError();
+    if (square(xPosError) + square(yPosError) > m_SquaredTranslationPosToleranceMeters) {
+      return false;
+    }
+    double xVelError = m_xController.getVelocityError();
+    double yVelError = m_yController.getVelocityError();
+    if (square(xVelError) + square(yVelError) > m_SquaredTranslationVelToleranceMetersPerDt) {
+      return false;
+    }
+    return m_angleController.atSetpoint();
+  }
+
+  @Override
+  public boolean isFinished() {
+    return atSetpoint();
+  }
+}

--- a/src/main/java/frc/robot/commands/FaceReef.java
+++ b/src/main/java/frc/robot/commands/FaceReef.java
@@ -12,8 +12,8 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants;
+import frc.robot.Constants.DriveCommandConstants;
 import frc.robot.Constants.DriveConstants;
-import frc.robot.Constants.ReefConstants;
 import frc.robot.subsystems.DriveSubsystem;
 import frc.robot.utilities.FaceReefUtil;
 import frc.robot.utilities.PIDF;
@@ -25,12 +25,13 @@ public class FaceReef extends Command {
   Supplier<Double> m_yVelocitySupplier;
   FaceReefUtil m_reef;
 
-  private static final TunablePIDF targetTurningPIDF = new TunablePIDF("Reef.turningPIDF", ReefConstants.kTurningPIDF);
+  private static final TunablePIDF turningPIDF = new TunablePIDF("Reef.turningPIDF",
+    DriveCommandConstants.kTurningPIDF);
 
-  private ProfiledPIDController m_thetaController = new ProfiledPIDController(
-    targetTurningPIDF.get().p(),
-    targetTurningPIDF.get().i(),
-    targetTurningPIDF.get().d(),
+  private ProfiledPIDController m_angleController = new ProfiledPIDController(
+    turningPIDF.get().p(),
+    turningPIDF.get().i(),
+    turningPIDF.get().d(),
     new TrapezoidProfile.Constraints(
       DriveConstants.kMaxAngularSpeedRadiansPerSecond,
       DriveConstants.kMaxAngularAccelerationRadiansPerSecondSquared),
@@ -49,7 +50,7 @@ public class FaceReef extends Command {
   @Override
   public void initialize() {
     Pose2d robotPose = m_drive.getPose();
-    m_thetaController.reset(
+    m_angleController.reset(
       m_reef.getRotationDeviation(robotPose).getRadians(),
       m_drive.getAngularVelocity()
     );
@@ -62,18 +63,18 @@ public class FaceReef extends Command {
     Rotation2d rotationDeviation = m_reef.getRotationDeviation(robotPose);
 
     updateConstants();
-    double thetaVelocity = m_thetaController.calculate(rotationDeviation.getRadians());
+    double angleVelocity = m_angleController.calculate(rotationDeviation.getRadians());
     m_drive.drive(
       m_xVelocitySupplier.get(),
-      m_yVelocitySupplier.get(), 
-      thetaVelocity,
+      m_yVelocitySupplier.get(),
+      angleVelocity,
       true);
   }
 
   private void updateConstants() {
-    if (targetTurningPIDF.hasChanged()) {
-      PIDF pidf = targetTurningPIDF.get();
-      m_thetaController.setPID(pidf.p(), pidf.i(), pidf.d());
+    if (turningPIDF.hasChanged()) {
+      PIDF pidf = turningPIDF.get();
+      m_angleController.setPID(pidf.p(), pidf.i(), pidf.d());
     }
   }
 }

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -34,55 +34,24 @@ import frc.robot.Constants;
 import frc.robot.Constants.AutoConstants;
 import frc.robot.Constants.CameraConstants;
 import frc.robot.Constants.DriveConstants;
+import frc.robot.Constants.SwerveModuleConstants;
 import frc.robot.utilities.ElevatorAccelInterp;
 import frc.robot.utilities.TrapezoidalConstraint;
 
 public class DriveSubsystem extends SubsystemBase {
-  private final SwerveModule m_frontLeft = //Q1
-      new SwerveModule(
-          DriveConstants.kFrontLeftDriveMotorPort,
-          DriveConstants.kFrontLeftTurningMotorPort,
-          DriveConstants.kFrontLeftTurningEncoderPort,
-          DriveConstants.kFrontLeftDriveReversed,
-          DriveConstants.kFrontLeftTurningMotorReversed,
-          DriveConstants.kFrontLeftEncoderReversed,
-          DriveConstants.kFrontLeftEncoderOffset);
-
-  private final SwerveModule m_rearLeft = //Q2
-      new SwerveModule(
-          DriveConstants.kRearLeftDriveMotorPort,
-          DriveConstants.kRearLeftTurningMotorPort,
-          DriveConstants.kRearLeftTurningEncoderPorts,
-          DriveConstants.kRearLeftDriveReversed,
-          DriveConstants.kRearLeftTurningMotorReversed,
-          DriveConstants.kRearLeftEncoderReversed,
-          DriveConstants.kRearLeftEncoderOffset);
-
-  private final SwerveModule m_rearRight = //Q3
-      new SwerveModule(
-          DriveConstants.kRearRightDriveMotorPort,
-          DriveConstants.kRearRightTurningMotorPort,
-          DriveConstants.kRearRightTurningEncoderPorts,
-          DriveConstants.kRearRightDriveReversed,
-          DriveConstants.kRearRightTurningMotorReversed,
-          DriveConstants.kRearRightEncoderReversed,
-          DriveConstants.kRearRightEncoderOffset);
-
-  private final SwerveModule m_frontRight = //Q4
-      new SwerveModule(
-          DriveConstants.kFrontRightDriveMotorPort,
-          DriveConstants.kFrontRightTurningMotorPort,
-          DriveConstants.kFrontRightTurningEncoderPorts,
-          DriveConstants.kFrontRightDriveReversed,
-          DriveConstants.kFrontRightTurningMotorReversed,
-          DriveConstants.kFrontRightEncoderReversed,
-          DriveConstants.kFrontRightEncoderOffset);
+  // Order must correspond to that of m_modules.
+  private static final SwerveDriveKinematics kDriveKinematics = new SwerveDriveKinematics(
+    new Translation2d(DriveConstants.kWheelBase / 2.0, DriveConstants.kTrackWidth / 2.0),
+    new Translation2d(-DriveConstants.kWheelBase / 2.0, DriveConstants.kTrackWidth / 2.0),
+    new Translation2d(-DriveConstants.kWheelBase / 2.0, -DriveConstants.kTrackWidth / 2.0),
+    new Translation2d(DriveConstants.kWheelBase / 2.0, -DriveConstants.kTrackWidth / 2.0)
+  );
 
   private final SwerveModule[] m_modules = new SwerveModule[]{
-    m_frontLeft,
-    m_rearLeft,
-    m_rearRight,
-    m_frontRight
+    new SwerveModule(SwerveModuleConstants.kFrontLeftSwerveConfig),
+    new SwerveModule(SwerveModuleConstants.kRearLeftSwerveConfig),
+    new SwerveModule(SwerveModuleConstants.kRearRightSwerveConfig),
+    new SwerveModule(SwerveModuleConstants.kFrontRightSwerveConfig)
   };
 
   private Translation2d m_idealVelocity = new Translation2d(0.0, 0.0);
@@ -104,13 +73,13 @@ public class DriveSubsystem extends SubsystemBase {
 
   // Odometry class for tracking robot pose
   private SwerveDrivePoseEstimator m_odometry =
-      new SwerveDrivePoseEstimator(
-        DriveConstants.kDriveKinematics,
-        getUncorrectedRotation2d(),
-        getPositions(),
-        m_initialPose,
-        DriveConstants.stateStdDeviations,
-        DriveConstants.visionStdDeviations);
+    new SwerveDrivePoseEstimator(
+      kDriveKinematics,
+      getUncorrectedRotation2d(),
+      getPositions(),
+      m_initialPose,
+      DriveConstants.stateStdDeviations,
+      DriveConstants.visionStdDeviations);
 
   private final Field2d m_field = new Field2d();
 
@@ -139,19 +108,19 @@ public class DriveSubsystem extends SubsystemBase {
     }
 
     AutoBuilder.configure(
-        this::getPose, // Robot pose supplier
-        this::initOdometry, // Method to reset odometry (will be called if your auto has a starting pose)
-        this::getSpeeds, // ChassisSpeeds supplier. MUST BE ROBOT RELATIVE
-        (speeds, feedforwards) -> driveRobotRelative(speeds), // Method that will drive the robot given ROBOT RELATIVE ChassisSpeeds
-        new PPHolonomicDriveController( // HolonomicPathFollowerConfig, this should likely live in your Constants class
-            AutoConstants.kTranslationHolonomicPID, // Translation PID constants
-            AutoConstants.kRotationHolonomicPID // Rotation PID constants
-        ), // Drive base radius in meters. Distance from robot center to furthest module.
-        config, // Default path replanning config. See the API for the options here
-        () -> {
-          return DriverStation.getAlliance().get() == Alliance.Red;
-        },
-        this // Reference to this subsystem to set requirements
+      this::getPose, // Robot pose supplier
+      this::initOdometry, // Method to reset odometry (will be called if your auto has a starting pose)
+      this::getSpeeds, // ChassisSpeeds supplier. MUST BE ROBOT RELATIVE
+      (speeds, feedforwards) -> driveRobotRelative(speeds), // Method that will drive the robot given ROBOT RELATIVE ChassisSpeeds
+      new PPHolonomicDriveController( // HolonomicPathFollowerConfig, this should likely live in your Constants class
+          AutoConstants.kTranslationHolonomicPID, // Translation PID constants
+          AutoConstants.kRotationHolonomicPID // Rotation PID constants
+      ), // Drive base radius in meters. Distance from robot center to furthest module.
+      config, // Default path replanning config. See the API for the options here
+      () -> {
+        return DriverStation.getAlliance().get() == Alliance.Red;
+      },
+      this // Reference to this subsystem to set requirements
     );
   }
 
@@ -207,7 +176,7 @@ public class DriveSubsystem extends SubsystemBase {
   }
 
   private ChassisSpeeds getSpeeds() {
-    return DriveConstants.kDriveKinematics.toChassisSpeeds(getModuleStates());
+    return kDriveKinematics.toChassisSpeeds(getModuleStates());
   }
 
   public void initOdometry(Pose2d initialPose) {
@@ -237,8 +206,7 @@ public class DriveSubsystem extends SubsystemBase {
         m_idealVelocity.getX(), m_idealVelocity.getY(), m_idealAngularVelocity, getEstimatedRotation2d())
       : new ChassisSpeeds(m_idealVelocity.getX(), m_idealVelocity.getY(), m_idealAngularVelocity);
     var swerveModuleStates =
-      DriveConstants.kDriveKinematics.toSwerveModuleStates(
-        ChassisSpeeds.discretize(chassisSpeeds, Constants.kDt));
+      kDriveKinematics.toSwerveModuleStates(ChassisSpeeds.discretize(chassisSpeeds, Constants.kDt));
 
     setModuleStates(swerveModuleStates);
   }
@@ -252,7 +220,7 @@ public class DriveSubsystem extends SubsystemBase {
   private void driveRobotRelative(ChassisSpeeds robotRelativeSpeeds) {
     ChassisSpeeds targetSpeeds = ChassisSpeeds.discretize(robotRelativeSpeeds, Constants.kDt);
 
-    SwerveModuleState[] targetStates = DriveConstants.kDriveKinematics.toSwerveModuleStates(targetSpeeds);
+    SwerveModuleState[] targetStates = kDriveKinematics.toSwerveModuleStates(targetSpeeds);
     setModuleStates(targetStates);
   }
 

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -254,6 +254,11 @@ public class DriveSubsystem extends SubsystemBase {
     return m_odometry.getEstimatedPosition().getRotation();
   }
 
+  /** Return ideal translational velocity of robot in meters/sec. */
+  public Translation2d getVelocity() {
+    return m_idealVelocity;
+  }
+
   /** Return ideal angular velocity of robot in radians/sec. */
   public double getAngularVelocity() {
     return m_idealAngularVelocity;

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -116,8 +116,7 @@ public class DriveSubsystem extends SubsystemBase {
 
   /** Creates a new DriveSubsystem. */
   public DriveSubsystem(CameraSubsystem cameraSystem) {
-    m_cameraSystem = cameraSystem;    
-    
+    m_cameraSystem = cameraSystem;
     m_velocityProfile = new TrapezoidalConstraint(
       DriveConstants.kMaxSpeedMetersPerSecond,
       () -> ElevatorAccelInterp.heightToMaxAcceleration(0.0), //TODO: Get actual elevator height

--- a/src/main/java/frc/robot/subsystems/HandlerSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/HandlerSubsystem.java
@@ -1,22 +1,14 @@
 package frc.robot.subsystems;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-
-import com.revrobotics.REVLibError;
 import com.revrobotics.RelativeEncoder;
-import com.revrobotics.spark.SparkBase.ResetMode;
 import com.revrobotics.spark.SparkLowLevel.MotorType;
 import com.revrobotics.spark.SparkMax;
-import com.revrobotics.spark.config.ClosedLoopConfig.FeedbackSensor;
-import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
-import com.revrobotics.spark.config.SparkMaxConfig;
 
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.Constants;
 import frc.robot.Constants.HandlerConstants;
+import frc.robot.utilities.SparkUtil;
 
 public class HandlerSubsystem extends SubsystemBase {
   private enum State {
@@ -36,26 +28,13 @@ public class HandlerSubsystem extends SubsystemBase {
   private final double m_intakeSpeed = HandlerConstants.kIntakeSpeed;
   private final double m_ejectSpeed = HandlerConstants.kEjectSpeed;
 
-  public HandlerSubsystem(int driveMotorChannel) {
+  public HandlerSubsystem(int motorID, SparkUtil.Config motorConfig) {
     m_chooser.setDefaultOption("Empty", State.EMPTY);
     m_chooser.addOption("Preloaded", State.LOADED);
     SmartDashboard.putData(m_chooser);
 
-    m_motor = new SparkMax(driveMotorChannel, MotorType.kBrushless);
-
-    SparkMaxConfig config = new SparkMaxConfig();
-    config.inverted(HandlerConstants.kMotorReversed)
-      .smartCurrentLimit(HandlerConstants.kMotorCurrentLimit)
-      .idleMode(IdleMode.kBrake);
-    config.encoder
-      .velocityConversionFactor(HandlerConstants.kVelocityConversionFactor);
-    config.closedLoop
-      .feedbackSensor(FeedbackSensor.kPrimaryEncoder);
-
-    REVLibError configureError = m_motor.configure(config, ResetMode.kResetSafeParameters, Constants.kPersistMode);
-    if (configureError != REVLibError.kOk) {
-      throw new UncheckedIOException("Failed to configure handler motor", new IOException());
-    }
+    m_motor = new SparkMax(motorID, MotorType.kBrushless);
+    SparkUtil.configureMotor(m_motor, motorConfig);
 
     m_encoder = m_motor.getEncoder();
 

--- a/src/main/java/frc/robot/subsystems/HandlerSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/HandlerSubsystem.java
@@ -69,14 +69,14 @@ public class HandlerSubsystem extends SubsystemBase {
   public void intake() {
     switch (m_state) {
       case EMPTY:
-      case CANCELLING: {  
+      case CANCELLING: {
         m_motor.set(m_intakeSpeed);
         m_state = State.INTAKING;
         break;
       }
-      case INTAKING: 
-      case LOADING: 
-      case LOADED: 
+      case INTAKING:
+      case LOADING:
+      case LOADED:
       case EJECTING: {
         break;
       }
@@ -91,9 +91,9 @@ public class HandlerSubsystem extends SubsystemBase {
         break;
       }
       case EMPTY:
-      case LOADING: 
-      case LOADED: 
-      case EJECTING: 
+      case LOADING:
+      case LOADED:
+      case EJECTING:
       case CANCELLING: {
         break;
       }
@@ -102,11 +102,11 @@ public class HandlerSubsystem extends SubsystemBase {
 
   public void eject() {
     switch (m_state) {
-      case EMPTY: 
-      case INTAKING: 
-      case LOADING: 
-      case EJECTING: 
-      case CANCELLING:{
+      case EMPTY:
+      case INTAKING:
+      case LOADING:
+      case EJECTING:
+      case CANCELLING: {
         break;
       }
       case LOADED: {

--- a/src/main/java/frc/robot/subsystems/Pololu4079.java
+++ b/src/main/java/frc/robot/subsystems/Pololu4079.java
@@ -1,0 +1,95 @@
+package frc.robot.subsystems;
+
+import edu.wpi.first.wpilibj.DigitalInput;
+import edu.wpi.first.wpilibj.DutyCycle;
+import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants;
+import frc.robot.utilities.ValueCache;
+
+/** Distance/proximity sensor based on the Pololu 4079 (https://www.pololu.com/product/4079). */
+public class Pololu4079 extends SubsystemBase {
+  private final DutyCycle m_dutyCycle;
+  private final double m_max_distance; // Meters.
+  // Debounce time is rounded up to a multiple of the scheduling period.
+  private final double m_debounceSec;
+  private final ValueCache<Double> m_distanceCache; // Meters.
+  // Refresh distance reading at most once per scheduling period.
+  private static final long ttlMicroseconds = (long)(Constants.kDt * 1_000_000.0);
+  // Time at which detection transitioned to proximate, or infinity if not proximate. Only used
+  // if debouncing is enabled.
+  private double m_proximateT0Sec;
+
+  private Pololu4079(DigitalInput digitalInput, double max_distance, double debounceSec) {
+    m_dutyCycle = new DutyCycle(digitalInput);
+    m_max_distance = max_distance;
+    m_debounceSec = debounceSec;
+    m_distanceCache = new ValueCache<>(this::getDistanceImpl, ttlMicroseconds);
+  }
+
+  /**
+   * Pololu4079(channel) constructs a distance sensor. isProximate() always returns false
+   * when so constructed.
+   */
+  public Pololu4079(int channel) {
+    this(new DigitalInput(channel), -1.0, 0.0);
+  }
+
+  /**
+   * Pololu4079(channel, max_distance, debounceSec) initializes a proximity sensor such that
+   * isProximate() considers detections no more than max_distance meters away as proximate, as
+   * long as proximate detection has persisted for at least debounceSec seconds.
+   */
+  public Pololu4079(int channel, double max_distance, double debounceSec) {
+    this(new DigitalInput(channel), max_distance,
+      Math.ceil(debounceSec / Constants.kDt) * Constants.kDt);
+  }
+
+  private double getDistanceImpl() {
+    // Valid pulse width is approximately 1.0ms to 1.75ms, with ~5% timing uncertainty.
+    // A ~2.0ms pulse width indicates no detection, so treat anything above 1.85ms as
+    // no detection.
+    double distance; // Meters.
+    double pulseMs = m_dutyCycle.getHighTimeNanoseconds() / 1_000_000.0;
+    if (pulseMs <= 1.85) {
+      distance = Math.max(4.0 * (pulseMs - 1.0), 0.0);
+    } else {
+      distance = Double.POSITIVE_INFINITY;
+    }
+    return distance;
+  }
+
+  public double getDistance() {
+    return m_distanceCache.get();
+  }
+
+  private double getTimeSec() {
+    return (double)RobotController.getFPGATime() / 1_000_000.0;
+  }
+
+  private boolean isProximateImpl() {
+    return getDistance() <= m_max_distance;
+  }
+
+  public boolean isProximate() {
+    if (m_debounceSec != 0.0) {
+      return m_proximateT0Sec + m_debounceSec <= getTimeSec();
+    } else {
+      return isProximateImpl();
+    }
+  }
+
+  @Override
+  public void periodic() {
+    // Only read the distance if necessary for debouncing.
+    if (m_debounceSec != 0.0) {
+      if (isProximateImpl()) {
+        if (m_proximateT0Sec == Double.POSITIVE_INFINITY) {
+          m_proximateT0Sec = getTimeSec();
+        }
+      } else {
+        m_proximateT0Sec = Double.POSITIVE_INFINITY;
+      }
+    }
+  }
+}

--- a/src/main/java/frc/robot/subsystems/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/SwerveModule.java
@@ -68,7 +68,7 @@ public class SwerveModule {
       boolean turningEncoderReversed,
       Rotation2d encoderOffset) {
     m_driveMotor = new SparkMax(driveMotorChannel, MotorType.kBrushless);
-    
+
     SparkMaxConfig config = new SparkMaxConfig();
     config.closedLoopRampRate(SwerveModuleConstants.kDriveMotorRampRate)
       .inverted(driveMotorReversed)
@@ -93,7 +93,7 @@ public class SwerveModule {
 
     m_drivePositionCache = new ValueCache<Double>(this::getPlausibleDrivePosition, SwerveModuleConstants.kValueCacheTtlMicroseconds);
     m_driveVelocityCache = new ValueCache<Double>(this::getPlausibleDriveVelocity, SwerveModuleConstants.kValueCacheTtlMicroseconds);
- 
+
     m_absoluteRotationEncoderOffset = encoderOffset;
 
     m_absoluteRotationEncoder = new CANcoder(turningEncoderChannel);
@@ -128,7 +128,7 @@ public class SwerveModule {
     m_turningPIDController = m_turningMotor.getClosedLoopController();
     SwerveModuleConstants.kAutoTurningPIDF.controllerSet(turningConfig.closedLoop, SwerveModuleConstants.kAutoPIDFSlotID);
     SwerveModuleConstants.kTeleopTurningPIDF.controllerSet(turningConfig.closedLoop, SwerveModuleConstants.kTeleopPIDFSlotID);
-    
+
     REVLibError configureTurningMotorError = m_turningMotor.configure(turningConfig, ResetMode.kResetSafeParameters, Constants.kPersistMode);
     if (configureTurningMotorError != REVLibError.kOk) {
       throw new UncheckedIOException("Failed to configure turning motor", new IOException());
@@ -204,7 +204,7 @@ public class SwerveModule {
     desiredState.optimize(m_prevAngle);
 
     m_drivePIDController.setReference(desiredState.speedMetersPerSecond, ControlType.kVelocity, m_PIDFSlotID);
-    
+
     if (!desiredState.angle.equals(m_prevAngle)) {
       // deltaAngle is in [-pi..pi], which is added (intentionally unconstrained) to m_prevAngle.
       // This causes the module to turn e.g. 4 degrees rather than -356 degrees.

--- a/src/main/java/frc/robot/utilities/FaceStationUtil.java
+++ b/src/main/java/frc/robot/utilities/FaceStationUtil.java
@@ -32,7 +32,7 @@ public class FaceStationUtil {
     ArrayList<Pose2d> coralStations;
     switch (alliance) {
       default: assert false;
-      case Blue: { 
+      case Blue: {
         coralStations = FieldConstants.kBlueCoralStations;
         break;
       }

--- a/src/main/java/frc/robot/utilities/SparkUtil.java
+++ b/src/main/java/frc/robot/utilities/SparkUtil.java
@@ -1,0 +1,113 @@
+package frc.robot.utilities;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+
+import com.revrobotics.REVLibError;
+import com.revrobotics.spark.ClosedLoopSlot;
+import com.revrobotics.spark.SparkBase.ResetMode;
+import com.revrobotics.spark.SparkFlex;
+import com.revrobotics.spark.SparkMax;
+import com.revrobotics.spark.config.ClosedLoopConfig.FeedbackSensor;
+import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
+import com.revrobotics.spark.config.SparkFlexConfig;
+import com.revrobotics.spark.config.SparkMaxConfig;
+
+import frc.robot.Constants;
+
+public class SparkUtil {
+  public record PIDFSlot (PIDF pidf, ClosedLoopSlot slot) {}
+  public record Config (
+    int currentLimit, double rampRate, boolean invert,
+    double velocityConversionFactor, double positionConversionFactor,
+    double maxVelocity, double maxAcceleration,
+    ArrayList<PIDFSlot> pidfSlots
+  ) {
+    public Config withInvert(boolean invert) {
+      return new Config(
+        this.currentLimit, this.rampRate, invert,
+        this.velocityConversionFactor, this.positionConversionFactor,
+        this.maxVelocity, this.maxAcceleration,
+        this.pidfSlots);
+    }
+  }
+
+  private static void configureMotorImpl(SparkMax motor, Config config, SparkMax leader) {
+    SparkMaxConfig motorConfig = new SparkMaxConfig();
+    motorConfig
+      .smartCurrentLimit(config.currentLimit)
+      .closedLoopRampRate(config.rampRate)
+      .idleMode(IdleMode.kBrake);
+    if (leader != null) {
+      motorConfig.follow(leader, config.invert);
+    } else {
+      motorConfig.inverted(config.invert);
+    }
+    motorConfig.encoder
+      .velocityConversionFactor(config.velocityConversionFactor)
+      .positionConversionFactor(config.positionConversionFactor);
+    motorConfig.closedLoop
+      .feedbackSensor(FeedbackSensor.kPrimaryEncoder)
+      .maxMotion
+        .maxVelocity(config.maxVelocity)
+        .maxAcceleration(config.maxAcceleration);
+
+    for (PIDFSlot pidfSlot : config.pidfSlots) {
+      pidfSlot.pidf.controllerSet(motorConfig.closedLoop, pidfSlot.slot);
+    }
+
+    REVLibError configureError = motor.configure(motorConfig, ResetMode.kResetSafeParameters,
+      Constants.kPersistMode);
+    if (configureError != REVLibError.kOk) {
+      throw new UncheckedIOException("Failed to configure motor", new IOException());
+    }
+  }
+
+  public static void configureMotor(SparkMax motor, Config config) {
+    configureMotorImpl(motor, config, null);
+  }
+
+  public static void configureFollowerMotor(SparkMax motor, Config config, SparkMax leader) {
+    configureMotorImpl(motor, config, leader);
+  }
+
+  private static void configureMotorImpl(SparkFlex motor, Config config, SparkFlex leader) {
+    SparkFlexConfig motorConfig = new SparkFlexConfig();
+    motorConfig
+      .smartCurrentLimit(config.currentLimit)
+      .closedLoopRampRate(config.rampRate)
+      .idleMode(IdleMode.kBrake);
+    if (leader != null) {
+      motorConfig.follow(leader, config.invert);
+    } else {
+      motorConfig.inverted(config.invert);
+    }
+    motorConfig.encoder
+      .velocityConversionFactor(config.velocityConversionFactor)
+      .positionConversionFactor(config.positionConversionFactor);
+    motorConfig.closedLoop
+      .feedbackSensor(FeedbackSensor.kPrimaryEncoder)
+      .maxMotion
+        .maxVelocity(config.maxVelocity)
+        .maxAcceleration(config.maxAcceleration);
+
+    for (PIDFSlot pidfSlot : config.pidfSlots) {
+      pidfSlot.pidf.controllerSet(motorConfig.closedLoop, pidfSlot.slot);
+    }
+
+    REVLibError configureError = motor.configure(motorConfig, ResetMode.kResetSafeParameters,
+      Constants.kPersistMode);
+    if (configureError != REVLibError.kOk) {
+      throw new UncheckedIOException("Failed to configure motor", new IOException());
+    }
+  }
+
+  public static void configureMotor(SparkFlex motor, Config config) {
+    configureMotorImpl(motor, config, null);
+  }
+
+  public static void configureFollowerMotor(SparkFlex motor, Config config, SparkFlex leader) {
+    configureMotorImpl(motor, config, leader);
+  }
+}

--- a/src/main/java/frc/robot/utilities/TunableDouble.java
+++ b/src/main/java/frc/robot/utilities/TunableDouble.java
@@ -10,7 +10,7 @@ public class TunableDouble {
   private final NetworkTableEntry m_dashboardEntry;
   private final double m_defaultValue;
   private double m_currentValue;
-  
+
   public TunableDouble(String key, double defaultValue) {
     m_defaultValue = defaultValue;
     if (Constants.kEnableTuning) {


### PR DESCRIPTION
This pull request includes three systems on which other parts of the code can build:

- `Pololu4079` implements distance and proximity sensing for the "AndyMark" ToF sensor.
- `SparkUtil` encapsulates all the boilerplate for Spark Max/Flex motor configuration.
- `DriveToPose` implements direct automatic driving to a specified pose.

I've already refactored `Crane` to use `SparkUtil`, but that subsystem isn't ready yet, and I'd like to get these changes committed so we can work in parallel on the handler and various automation.

`DriveToPose` combines x,y PID controllers in the same way I expect the `Crane` subsystem to combine pivot,elevator PID controllers. Driving was easier to reason about, so I implemented this first in order to get the algorithm figured out.