### PR TITLE
Fix rebase error

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -206,10 +206,6 @@ public final class Constants {
       kFrontRightDriveMotorConfig, kFrontRightTurningMotorConfig,
       false, new Rotation2d(Units.rotationsToRadians(5.805890))
     );
-    public static final Rotation2d kFrontLeftEncoderOffset = new Rotation2d(Units.rotationsToRadians(6.05174)); //Q1
-    public static final Rotation2d kRearLeftEncoderOffset = new Rotation2d(Units.rotationsToRadians(6.065900)); //Q2
-    public static final Rotation2d kRearRightEncoderOffset = new Rotation2d(Units.rotationsToRadians(0.475830)); //Q3
-    public static final Rotation2d kFrontRightEncoderOffset = new Rotation2d(Units.rotationsToRadians(5.805890)); //Q4
   }
 
   public static final class HandlerConstants {


### PR DESCRIPTION
Obsolete encoder offset constants were mistakenly moved rather than removed. Remove them.