### PR TITLE
Filter out high-ambiguity PhotonVision pose estimates

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -347,6 +347,7 @@ public final class Constants {
 
   public static final class CameraConstants {
     public static final boolean kEnable = true;
+    public static final double kMaxAmbiguity = 0.20;
     public static final List<CameraConfig> kCameraConfigs = List.of(
       new CameraConfig(
         "reefCamera",


### PR DESCRIPTION
My understanding of the odometry issues we saw today is that one of the cameras was intermittently seeing a single coral station AprilTag from a distance, and it was sometimes erroneously disambiguating the pose. None of the alternate pose estimation strategies work around this, so our best option is to reject high-ambiguity estimates.