### PR TITLE
Add ability to move easily to calibrate low-level crane PIDs

### DIFF
--- a/src/main/java/frc/robot/subsystems/Crane.java
+++ b/src/main/java/frc/robot/subsystems/Crane.java
@@ -463,6 +463,8 @@ public class Crane extends SubsystemBase {
     SmartDashboard.putNumber("Crane elevator height", m_elevatorEncoder.getPosition());
     SmartDashboard.putNumber("Crane sensor distance", m_distanceSensor.getDistance());
     SmartDashboard.putNumber("Crane elevator PID reference", m_leftElevatorMotor.getAppliedOutput());
+    SmartDashboard.putNumber("Crane elevator velocity", m_elevatorEncoder.getVelocity());
+    SmartDashboard.putNumber("Crane pivot velocity", m_pivotEncoder.getVelocity());
     switch (m_state) {
       case CRANING: {
         crane();


### PR DESCRIPTION
- already buttons for moving elevator and pivot to set positions
- added elevator and pivot velocity to SmartDashboard so it can be graphed
- `kEnableTuning` is set to false currently and would need to be flipped for tuning which will allow for changing the PIDF values for the elevator and pivot velocity controllers