### PR TITLE
Add Handler support for switching intake types

### DIFF
--- a/src/main/java/frc/robot/subsystems/HandlerSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/HandlerSubsystem.java
@@ -36,6 +36,7 @@ public class HandlerSubsystem extends SubsystemBase {
     HandlerConstants.kMotorPIDFVelocity);
 
   private State m_state = State.EMPTY;
+  private State m_stateOnEmpty = State.EMPTY;
   private final SparkFlex m_motor;
   private final SparkClosedLoopController m_motorController;
   private final RelativeEncoder m_encoder;
@@ -74,6 +75,62 @@ public class HandlerSubsystem extends SubsystemBase {
       HandlerConstants.kDebounceTime);
   }
 
+  private void intakeCoralImpl() {
+    m_motorController.setReference(
+      HandlerConstants.kIntakeSpeedCoral,
+      ControlType.kMAXMotionVelocityControl,
+      HandlerConstants.kPIDFSlotVelocity);
+    m_state = State.INTAKING_CORAL;
+  }
+
+  private void intakeAlgaeImpl() {
+    m_motorController.setReference(
+      HandlerConstants.kIntakeSpeedAlgae,
+      ControlType.kMAXMotionVelocityControl,
+      HandlerConstants.kPIDFSlotVelocity);
+    m_state = State.INTAKING_ALGAE;
+  }
+
+  private void cancelCoralImpl() {
+    m_motor.stopMotor();
+    m_state = State.CANCELLING_CORAL;
+  }
+
+  private void cancelAlgaeImpl() {
+    m_motor.stopMotor();
+    m_state = State.CANCELLING_ALGAE;
+  }
+
+  // Coral/algae intake can cancel each other, and once the handler is empty, this method
+  // transitions to intaking the other type of gamepiece.
+  private void onEmpty() {
+    switch (m_stateOnEmpty) {
+      case EMPTY: {
+        m_state = State.EMPTY;
+        break;
+      }
+      case INTAKING_CORAL: {
+        intakeCoralImpl();
+        break;
+      }
+      case INTAKING_ALGAE: {
+        intakeAlgaeImpl();
+        break;
+      }
+      case LOADING_CORAL:
+      case LOADED_CORAL:
+      case LOADED_ALGAE:
+      case EJECTING_CORAL:
+      case EJECTING_ALGAE:
+      case CANCELLING_CORAL:
+      case CANCELLING_ALGAE: {
+        assert(false);
+        break;
+      }
+    }
+    m_stateOnEmpty = State.EMPTY;
+  }
+
   public void initializePreloaded() {
     m_state = m_chooser.getSelected();
   }
@@ -90,21 +147,30 @@ public class HandlerSubsystem extends SubsystemBase {
     switch (m_state) {
       case EMPTY:
       case CANCELLING_CORAL: {
-        m_motorController.setReference(
-          HandlerConstants.kIntakeSpeedCoral,
-          ControlType.kMAXMotionVelocityControl,
-          HandlerConstants.kPIDFSlotVelocity);
-        m_state = State.INTAKING_CORAL;
+        intakeCoralImpl();
         break;
       }
-      case INTAKING_CORAL:
-      case INTAKING_ALGAE:
+      case INTAKING_CORAL: {
+        break;
+      }
+      case INTAKING_ALGAE: {
+        cancelAlgaeImpl();
+        m_stateOnEmpty = State.INTAKING_CORAL;
+        break;
+      }
       case LOADING_CORAL:
       case LOADED_CORAL:
-      case LOADED_ALGAE:
+      case LOADED_ALGAE: {
+        break;
+      }
       case EJECTING_CORAL:
-      case EJECTING_ALGAE:
+      case EJECTING_ALGAE: {
+        m_stateOnEmpty = State.INTAKING_CORAL;
+        break;
+      }
       case CANCELLING_ALGAE: {
+        cancelAlgaeImpl();
+        m_stateOnEmpty = State.INTAKING_CORAL;
         break;
       }
     }
@@ -114,21 +180,24 @@ public class HandlerSubsystem extends SubsystemBase {
     switch (m_state) {
       case EMPTY:
       case CANCELLING_ALGAE: {
-        m_motorController.setReference(
-          HandlerConstants.kIntakeSpeedAlgae,
-          ControlType.kMAXMotionVelocityControl,
-          HandlerConstants.kPIDFSlotVelocity);
-        m_state = State.INTAKING_ALGAE;
+        intakeAlgaeImpl();
         break;
       }
-      case INTAKING_CORAL:
+      case INTAKING_CORAL: {
+        cancelCoralImpl();
+        m_stateOnEmpty = State.INTAKING_ALGAE;
+        break;
+      }
       case INTAKING_ALGAE:
       case LOADING_CORAL:
       case LOADED_CORAL:
-      case LOADED_ALGAE:
+      case LOADED_ALGAE: {
+        break;
+      }
       case EJECTING_CORAL:
       case EJECTING_ALGAE:
       case CANCELLING_CORAL: {
+        m_stateOnEmpty = State.INTAKING_ALGAE;
         break;
       }
     }
@@ -136,17 +205,17 @@ public class HandlerSubsystem extends SubsystemBase {
 
   public void cancelIntake() {
     switch (m_state) {
+      case EMPTY: {
+        break;
+      }
       case INTAKING_CORAL: {
-        m_motor.stopMotor();
-        m_state = State.CANCELLING_CORAL;
+        cancelCoralImpl();
         break;
       }
       case INTAKING_ALGAE: {
-        m_motor.stopMotor();
-        m_state = State.CANCELLING_ALGAE;
+        cancelAlgaeImpl();
         break;
       }
-      case EMPTY:
       case LOADING_CORAL:
       case LOADED_CORAL:
       case LOADED_ALGAE:
@@ -259,7 +328,7 @@ public class HandlerSubsystem extends SubsystemBase {
         }
       }
       case LOADING_CORAL: {
-        if (m_backProxSensor.isProximate()){
+        if (m_backProxSensor.isProximate()) {
           m_motor.stopMotor();
           m_state = State.LOADED_CORAL;
         }
@@ -275,7 +344,7 @@ public class HandlerSubsystem extends SubsystemBase {
         double currentTime = Time.getTimeSeconds();
         if (currentTime - m_ejectDelayStartTime >= HandlerConstants.kEjectDelaySeconds) {
           m_motor.stopMotor();
-          m_state = State.EMPTY;
+          onEmpty();
         }
         break;
       }
@@ -283,7 +352,7 @@ public class HandlerSubsystem extends SubsystemBase {
         double currentTime = Time.getTimeSeconds();
         if (currentTime - m_ejectDelayStartTime >= HandlerConstants.kEjectDelaySeconds) {
           m_motor.stopMotor();
-          m_state = State.EMPTY;
+          onEmpty();
         }
         break;
       }
@@ -295,7 +364,7 @@ public class HandlerSubsystem extends SubsystemBase {
             HandlerConstants.kPIDFSlotVelocity);
           m_state = State.LOADING_CORAL;
         } else {
-          m_state = State.EMPTY;
+          onEmpty();
         }
         break;
       }
@@ -303,7 +372,7 @@ public class HandlerSubsystem extends SubsystemBase {
         if (m_algaeProxSensor.isProximate()) {
           m_state = State.LOADED_ALGAE;
         } else {
-          m_state = State.EMPTY;
+          onEmpty();
         }
         break;
       }


### PR DESCRIPTION
Enhance intakeCoral() and intakeAlgae() to cancel intake of the other gamepiece type if necessary, and initiate intake once cancellation, ejection, etc. is complete.

This resolves #158.