### PR TITLE
Update camera heights

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -358,14 +358,14 @@ public final class Constants {
       new CameraConfig(
         "reefCamera",
         new Transform3d(
-          0.279292, -0.137998, 0.317346,
+          0.279292, -0.137998, 0.315,
           new Rotation3d(0.0, 0.0, Units.degreesToRadians(21.5))),
         true
       ),
       new CameraConfig(
         "coralStationCamera",
         new Transform3d(
-          0.283631, -0.130006, 0.935310,
+          0.283631, -0.130006, 0.996,
           new Rotation3d(0.0, Units.degreesToRadians(-22.5), Units.degreesToRadians(9.5))),
         true
       )


### PR DESCRIPTION
Raise coral station camera, per elevator extension.

Re-calculate camera heights, assuming that the top of the 1x2 chassis tubes are 5.8" above the floor.