### PR TITLE
Update climber to use two motors and no absolute encoder

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -608,7 +608,8 @@ public final class Constants {
     public static final boolean kEnable = false;
     public static final int kLeftMotorID = 16;
     public static final int kRightMotorID = 17;
-    public static final double kMaxSpeedRadiansPerSecond = Math.toRadians(Math.PI);
+    public static final double kMaxSpeedRadiansPerSecond = Math.PI;
+    public static final double kMaxAccelerationRadiansPerSecondSquared = 4.0 * Math.PI;
     public static final double kMaxRange = Math.toRadians(-15.0);
     public static final double kMinRange = Math.toRadians(135.0);
     public static final double kInitialAngle = 0.0;
@@ -623,9 +624,10 @@ public final class Constants {
 
     public static final PIDF kVelocityPIDF = new PIDF(0.0, 0.0 , 0.0, 0.0);
 
-    public static final SparkUtil.PIDFSlot kMotorVelocityPIDF = new SparkUtil.PIDFSlot(
+    public static final ClosedLoopSlot kVelocitySlot = ClosedLoopSlot.kSlot0;
+    public static final SparkUtil.PIDFSlot kMotorVelocityPIDFSlot = new SparkUtil.PIDFSlot(
       kVelocityPIDF,
-      ClosedLoopSlot.kSlot0
+      kVelocitySlot
     );
 
     public static final boolean kInvertLeftMotor = false;
@@ -635,10 +637,10 @@ public final class Constants {
       kInvertLeftMotor,
       kVelocityConversionFactor,
       kAngleConversionFactor,
-      0.0,
-      0.0,
+      kMaxSpeedRadiansPerSecond,
+      kMaxAccelerationRadiansPerSecondSquared,
       new ArrayList<>() {{
-        add(kMotorVelocityPIDF);
+        add(kMotorVelocityPIDFSlot);
       }}
     );
   }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -606,41 +606,39 @@ public final class Constants {
 
   public static final class ClimberConstants {
     public static final boolean kEnable = false;
-    public static final int kMotorID = 16;
-    public static final int kEncoderChannelAbs = 2;
-    public static final double kMaxSpeed = 0.5; //TODO: Set. This number is from ACDC.
-    public static final double kMaxRange = Math.toRadians(90); //TODO: Set.
-    public static final double kMinRange = Math.toRadians(0); //TODO: Set
-    public static final double kZeroOffset = 0.0;
-    public static final double kAngleTolerance = Math.toRadians(0.02); //TODO: Set.
+    public static final int kLeftMotorID = 16;
+    public static final int kRightMotorID = 17;
+    public static final double kMaxSpeedRadiansPerSecond = Math.toRadians(Math.PI);
+    public static final double kMaxRange = Math.toRadians(-15.0);
+    public static final double kMinRange = Math.toRadians(135.0);
+    public static final double kInitialAngle = 0.0;
+    public static final double kAngleTolerance = Math.toRadians(0.02);
 
-    //TODO: find gear ratio and meters per rotation
-    public static final double kGearRatio = 144.0;
-    // With no gear reduction each motor rotation moves the climber 0.012 meters
+    public static final double kGearRatio = 9.0 * 4.0 * 3.0;
     public static final double kAngleConversionFactor = 2.0 * Math.PI / kGearRatio;
 
     // The native velocity units are motor rotations [aka revolutions] per minute (RPM),
     // but we want meters per second.
     public static final double kVelocityConversionFactor = kAngleConversionFactor / 60.0;
 
-    public static final PIDF kMotorPIDF = new PIDF(0.0, 0.0 , 0.0, 0.0);
+    public static final PIDF kVelocityPIDF = new PIDF(0.0, 0.0 , 0.0, 0.0);
 
-    public static final SparkUtil.PIDFSlot kMotorVelocityPIDFSlot = new SparkUtil.PIDFSlot(
-      new PIDF(0.1, 0.0, 0.0, 0.0), //TODO: Tune.
+    public static final SparkUtil.PIDFSlot kMotorVelocityPIDF = new SparkUtil.PIDFSlot(
+      kVelocityPIDF,
       ClosedLoopSlot.kSlot0
     );
 
-    //TODO: Set.
+    public static final boolean kInvertLeftMotor = false;
     public static final SparkUtil.Config kMotorConfig = new SparkUtil.Config(
       40,
       0.1,
-      false,
+      kInvertLeftMotor,
       kVelocityConversionFactor,
       kAngleConversionFactor,
       0.0,
       0.0,
       new ArrayList<>() {{
-        add(kMotorVelocityPIDFSlot);
+        add(kMotorVelocityPIDF);
       }}
     );
   }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -136,7 +136,7 @@ public class RobotContainer {
         new RunCommand(
           () -> {
             m_climber.setSpeed(
-              getClimbInput() * ClimberConstants.kMaxSpeed
+              getClimbInput() * ClimberConstants.kMaxSpeedRadiansPerSecond
             );
           }, m_climber
         )

--- a/src/main/java/frc/robot/subsystems/ClimberSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ClimberSubsystem.java
@@ -3,15 +3,13 @@ package frc.robot.subsystems;
 import java.util.ArrayList;
 
 import com.revrobotics.RelativeEncoder;
+import com.revrobotics.spark.SparkBase.ControlType;
 import com.revrobotics.spark.SparkClosedLoopController;
 import com.revrobotics.spark.SparkFlex;
-import com.revrobotics.spark.SparkBase.ControlType;
 import com.revrobotics.spark.SparkLowLevel.MotorType;
 
-import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.Constants;
 import frc.robot.Constants.ClimberConstants;
 import frc.robot.utilities.PIDF;
 import frc.robot.utilities.SparkUtil;
@@ -25,11 +23,6 @@ public class ClimberSubsystem extends SubsystemBase {
   private final RelativeEncoder m_encoder;
   private final TunablePIDF m_motorPIDF =
     new TunablePIDF("Climber.velocityPIDF", ClimberConstants.kVelocityPIDF);
-  private final PIDController m_PIDController = new PIDController(
-    m_motorPIDF.get().p(),
-    m_motorPIDF.get().i(),
-    m_motorPIDF.get().d(),
-    m_motorPIDF.get().ff());
 
   private double m_idealSpeed;
 


### PR DESCRIPTION
The climber must be manually positioned to correspond with `kInitialAngle`.